### PR TITLE
Add warning to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Leap.loop(function(frame) {
 })
 ```
 
+### WARNING
+
+Leap.loop uses requestAnimationFrame internally, which *will not run* inside the
+background page of a Chrome extension, due to Chrome's implementation of it.
+
+In general, browsers optimize the load of requestAnimationFrame based on load, element visibility,
+battery status, etc. Chrome has chosen to optimize this by omitting the functionality
+altogether in the background.js of its extensions.
+
+So, if you're hacking on a Chrome extension, and you need to receive frames inside background.js,
+the best solution for now is to use the "Do-it-yourself loop" described below.
+
 ### Do-it-yourself loop
 
 To use the leap motion api do the following...


### PR DESCRIPTION
I added a warning to README.md about using Leap.loop inside the background.js of Chrome extensions... to avoid future head scratching.
