### PR TITLE
Fix scaleFactor() not return default scale if invalid

### DIFF
--- a/leap.js
+++ b/leap.js
@@ -1311,7 +1311,7 @@ var Motion = exports.Motion = {
    * and that specified in the fromFrame parameter.
    */
   scaleFactor: function(fromFrame) {
-    if (!this.valid || !fromFrame.valid) 1.0;
+    if (!this.valid || !fromFrame.valid) return 1.0;
     return Math.exp(this._scaleFactor - fromFrame._scaleFactor);
   }
 }


### PR DESCRIPTION
Got the commit to only contain the changes I want to contribute. Looks like you have set your linebreak to CRLF (i.e. Windows), whereas I am on OS X so my linebreak is LF only.
