### PR TITLE
Changed hand.palmDirection to hand.direction to match main API. Changed ...

### DIFF
--- a/lib/hand.js
+++ b/lib/hand.js
@@ -53,10 +53,10 @@ var Hand = exports.Hand = function(data) {
    * The direction is expressed as a unit vector pointing in the same
    * direction as the directed line from the palm position to the fingers.
    *
-   * @member Leap.Hand.prototype.palmDirection
+   * @member Leap.Hand.prototype.direction
    * @type {Array: [x,y,z]}
    */
-  this.palmDirection = data.palmDirection
+  this.direction = data.direction
   /**
    * The rate of change of the palm position in millimeters/second.
    *


### PR DESCRIPTION
Found a problem with the Hand instantiation, in that the direction object was named "direction" in the JSON data, but referenced as "palmDirection" in the Hand constructor. 

Since the Hand.palmDirection property couldn't have worked for anyone (it was undefined), I went ahead and renamed it to Hand.direction to match the standard Leap API.

...data.palmDirection to data.direction to match JSON.
