### PR TITLE
fix wrong Box class name in Mapper Example

### DIFF
--- a/examples/mapper.html
+++ b/examples/mapper.html
@@ -36,7 +36,7 @@
 
     var pointer = document.getElementById("pointer")
 
-    var box = new Leap.Box({size: 20})
+    var box = new Leap.UI.Box({size: 20})
     var cursor = new Leap.UI.Cursor();
 
     cursor.onCreate = function() {


### PR DESCRIPTION
was:

```
   Leap.Box
```

must:

```
   Leap.UI.Box
```
