### PR TITLE
fix bug with disconnected and reconnected LeapMotion

### DIFF
--- a/lib/base_connection.js
+++ b/lib/base_connection.js
@@ -15,10 +15,17 @@ Connection.prototype.handleOpen = function() {
 
 Connection.prototype.handleClose = function() {
   var connection = this;
-  this.openTimer = setTimeout(function() { connection.connect() }, 1000)
+  this.openTimer = setTimeout(function() { 
+    if(!connection.connected) {
+      return;
+    }
+    connection.socket = null;
+    connection.connect();
+  }, 1000)
 }
 
 Connection.prototype.disconnect = function() {
+  this.connected = false;
   if (!this.socket) return
   this.socket.close()
   this.socket = undefined

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -4,8 +4,9 @@ Connection.prototype.connect = function() {
   if (this.socket) return false
   var connection = this
   this.socket = new WebSocket("ws://" + this.host + ":6437")
-  this.socket.onopen = connection.handleOpen
+  this.socket.onopen = function() { connection.handleOpen(); }
   this.socket.onmessage = function(message) { connection.handleData(message.data) }
-  this.socket.onclose = connection.handleClose
+  this.socket.onclose = function() { connection.handleClose(); }
+  this.connected = true
   return true
 }


### PR DESCRIPTION
Fix bug with _WebSocket's onclose handler_. And also all behavior with disconnect, reconnect interaction.
# To Reproduce
## 1

Just turn off Leap device and then LeapJS library rise exception:

```
Uncaught TypeError: Object #<WebSocket> has no method 'connect' leap.js:1684
```

Because _Connection.prototype.handleClose_ function run in scope of _WebSocket_.
So there is little fix for it. 
## 2

Also after calling disconnect close handler also going to reconnect.

So i have add _this.connected_ flag to store user intention to prevent this behavior.
