### PR TITLE
Change Examples Index to Absolute Paths

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -3,14 +3,14 @@
 <p>Here are a few examples using the javascript api.</p>
 
 <dl>
-  <dt><a href="./dom-visualizer.html">DOM based visualizer</a></dt>
+  <dt><a href="/examples/dom-visualizer.html">DOM based visualizer</a></dt>
   <dd>This is a DOM based visualizer of the data contributed by <a href="https://github.com/juliangarnier">@juliangarnier</a> (big thank you!)</dd>
-  <dt><a href="./earthRotation/index.html">3D Globe</a></dt>
+  <dt><a href="/examples/earthRotation/index.html">3D Globe</a></dt>
   <dd>3D Spinnable globe, contributed by <a href="https://github.com/rtilton1">@rtilton1</a>. Ridiculously pretty.</dt>
-  <dt><a href="./visualizer.html">Three.js visualizer</a></dt>
+  <dt><a href="/examples/visualizer.html">Three.js visualizer</a></dt>
   <dd>Very basic visualizer of data using <a href="http://mrdoob.github.com/three.js/">Three.js</a></dd>
-  <dt><a href="./dumper.html">Dumper</a></dt>
+  <dt><a href="/examples/dumper.html">Dumper</a></dt>
   <dd>Displays JSON data coming from websocket</dd>
-  <dt><a href="./camera.html">Camera manipulation demo</a></dt>
+  <dt><a href="/examples/camera.html">Camera manipulation demo</a></dt>
   <dd>Allow movement of cube through grasping actions</dd>
 </dl>


### PR DESCRIPTION
The relative paths used in the example index.html page do not work - they try to find files relative to the root directory rather than the examples folder. Changed to using absolute paths.
