### PR TITLE
fix `invalid frame` problem

### DIFF
--- a/lib/frame.js
+++ b/lib/frame.js
@@ -123,6 +123,7 @@ var Frame = exports.Frame = function(data) {
       (pointable.tool ? hand.tools : hand.fingers).push(pointable);
     }
   }
+  this.gestures = []
   if (data.gestures) {
    /**
     * The list of Gesture objects detected in this frame, given in arbitrary order.
@@ -133,7 +134,6 @@ var Frame = exports.Frame = function(data) {
     * @member Frame.prototype.gestures[]
     * @type {Gesture}
     */
-    this.gestures = []
     for (var gestureIdx = 0, gestureCount = data.gestures.length; gestureIdx != gestureCount; gestureIdx++) {
       this.gestures.push(Gesture(data.gestures[gestureIdx]))
     }


### PR DESCRIPTION
When I browse the dumper.html, I always get the `invalid frame` hint, it's caused by the new `dump` function of `Frame`, when there is no gesture detected, the `gestures.length` will go wrong. And I believe the gesture is the same attribute as hand or pointables, so I simply put the line `this.gestures = []` out of the if clause. 
