### PR TITLE
Fixed typos and forced '/' on example url so child hrefs work correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Leap.loop(function(frame) {
 ```
 
 As well, you can call a special version of `Leap.loop` where you provide a second argument to the callback.
-This allows you to wait until you're ready to receieve further frame events. Here is an exmaple of
+This allows you to wait until you're ready to receieve further frame events. Here is an example of
 this approach.
 
 ```javascript
@@ -120,7 +120,7 @@ Inside the examples directory are a few great examples. To get them running, do 
 
 ### Node.js example
 
-To run the node.js example, run `node exmaples/node.js`.
+To run the node.js example, run `node examples/node.js`.
 
 ## Development
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -22,3 +22,8 @@
   <dt><a href="gestures-dump.html">Gesture JSON Print Out</a></dt>
   <dd>Prints out gesture data in JSON</dd>
 </dl>
+<script>
+var path = window.location.pathname;
+if (path[path.length-1] != '/')
+	window.location.pathname = path + '/';
+</script>


### PR DESCRIPTION
Relative hrefs on example page require a trailing '/' on the referencing page url.  Script added to append this '/' when missing.

Also examples mis-spelled 'exmaples' in docs.

Thanks!
