### PR TITLE
Node-webkit compatibility

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -1,4 +1,4 @@
-var inNode = typeof(window) === 'undefined';
+var inNode = typeof(global) !== 'undefined';
 
 var Frame = require('./frame').Frame
   , CircularBuffer = require("./circular_buffer").CircularBuffer


### PR DESCRIPTION
Make leap controller node-webkit friendly by checking _global_ variable instead of _window_
