### PR TITLE
Scoping error with default options in BaseConnection

### DIFF
--- a/leap.js
+++ b/leap.js
@@ -12,8 +12,8 @@ var BaseConnection = module.exports = function(opts) {
     heartbeatInterval: 100,
     requestProtocolVersion: 3
   });
-  this.host = opts.host;
-  this.port = opts.port;
+  this.host = this.opts.host;
+  this.port = this.opts.port;
   this.on('ready', function() {
     this.enableGestures(this.opts.enableGestures);
     if (this.opts.enableHeartbeat) this.startHeartbeat();

--- a/lib/base_connection.js
+++ b/lib/base_connection.js
@@ -11,8 +11,8 @@ var BaseConnection = module.exports = function(opts) {
     heartbeatInterval: 100,
     requestProtocolVersion: 3
   });
-  this.host = opts.host;
-  this.port = opts.port;
+  this.host = this.opts.host;
+  this.port = this.opts.port;
   this.on('ready', function() {
     this.enableGestures(this.opts.enableGestures);
     if (this.opts.enableHeartbeat) this.startHeartbeat();


### PR DESCRIPTION
Fix for connection host and port not getting set to default options if no options are passed in.
