### PR TITLE
Fixes #111. Create shared focusBlurHandler function reference for removal

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -27,16 +27,20 @@ Connection.prototype.startHeartbeat = function() {
 
   var windowVisible = true;
 
-  var focusListener = window.addEventListener('focus', function(e) { windowVisible = true; });
-  var blurListener = window.addEventListener('blur', function(e) { windowVisible = false; });
+  var focusBlurHandler = function(e) {
+    windowVisible = e.type === 'focus';
+  };
+
+  window.addEventListener('focus', focusBlurHandler);
+  window.addEventListener('blur', focusBlurHandler);
 
   this.on('disconnect', function() {
     if (connection.heartbeatTimer) {
       clearTimeout(connection.heartbeatTimer);
       delete connection.heartbeatTimer;
     }
-    window.removeEventListener('focus', focusListener);
-    window.removeEventListener('blur', blurListener);
+    window.removeEventListener('focus', focusBlurHandler);
+    window.removeEventListener('blur', focusBlurHandler);
   });
 
   this.heartbeatTimer = setInterval(function() {


### PR DESCRIPTION
I would've liked to include tests that spied on window.addEventListener and window.removeEventListener and compared the arguments for equality, but there is no mock/spy module in the project and wasn't sure if adding Sinon would be out of this bug's scope.

Signed-off-by: Rick Waldron waldron.rick@gmail.com
