### PR TITLE
No longer run automated tests on node 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,4 @@ language: node_js
 node_js:
   - "0.10"
   - "0.8"
-  - "0.6"
 script: make test


### PR DESCRIPTION
"node 0.6 is not supported officially any more since some time" - has
been causing errors for us of this sort:
https://github.com/npm/npm/issues/4391
