### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "leapjs",
-  "version": "0.6.4",
   "homepage": "https://github.com/leapmotion/leapjs",
   "description": "JavaScript client for the Leap Motion Controller",
   "main": "leap-0.6.4.js",


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property