### PR TITLE
BrowserConnection prototyping

### DIFF
--- a/lib/connection/browser.js
+++ b/lib/connection/browser.js
@@ -11,7 +11,7 @@ var BrowserConnection = module.exports = function(opts) {
 
 _.extend(BrowserConnection.prototype, BaseConnection.prototype);
 
-BrowserConnection.__proto__ = BaseConnection;
+// BrowserConnection.__proto__ = BaseConnection;
 
 BrowserConnection.prototype.useSecure = function(){
   return location.protocol === 'https:'


### PR DESCRIPTION
To avoid this warning in console's browsers :
"mutating the [[Prototype]] of an object will cause your code to run very slowly; instead create the object with the correct initial [[Prototype]] value using Object.create"

Not really a support for ECMAScript6 but a fix with underscore's method extend() already existing.

Research about Object.setPrototypeOf(); or Object.create(); must be done to really normalize the code regarding ES6.
