### PR TITLE
Fix mixed content  issue for browser connection

### DIFF
--- a/lib/connection/browser.js
+++ b/lib/connection/browser.js
@@ -34,7 +34,7 @@ BrowserConnection.prototype.setupSocket = function() {
   socket.onerror = function(error) {
 
     // attempt to degrade to ws: after one failed attempt for older Leap Service installations.
-    if (connection.useSecure() && connection.scheme === 'wss:'){
+    if (!connection.useSecure() && connection.scheme === 'wss:'){
       connection.scheme = 'ws:';
       connection.port = 6437;
       connection.disconnect();


### PR DESCRIPTION
When leap motion is not active and the SDK is loaded on a `https` page, all the browsers will throw error regarding `mixed content`. 

The issue was from the attempt to degrade from `wss` to `ws` if the connection to the web socket failed, but `ws` is insecure and is not allowed with `https`.