### PR TITLE
[FIX] Fix Dependabot ecstatic Dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,3 @@ open-in-browsers: build
 	open -a /Applications/Firefox.app test/helpers/browser.html
 	open -a /Applications/Safari.app test/helpers/browser.html
 	open -a /Applications/Google\ Chrome.app test/helpers/browser.html
-
-serve:
-	./node_modules/.bin/http-server .

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "grunt-contrib-watch": "^1.1.0",
     "grunt-exec": "^3.0.0",
     "grunt-string-replace": "^1.3.1",
-    "http-server": "^0.12.3",
     "jsdoc": "^3.6.6",
     "load-grunt-tasks": "^5.1.0",
     "mocha": "^8.2.1",


### PR DESCRIPTION
Dependabot is complaining about the ecstatic file server, which I believe is only used in `http-server`, which is only used in a vestigial preview command in the Makefile.

Since VS Code now has `live-server` previewing extensions, I'm just removing that command.

Hopefully this gets us back to a sinless universe.